### PR TITLE
fix kleine text foutjes

### DIFF
--- a/docs/content/nl/docs/API/pickupdays.md
+++ b/docs/content/nl/docs/API/pickupdays.md
@@ -1,11 +1,11 @@
 ---
-categories: ["api", "containers"]
-tags: ["api", "examples", "containers"]
-title: "Containers API"
-linkTitle: "Containers API"
+categories: ["api", "pickupdays"]
+tags: ["api", "examples", "pickupdays"]
+title: "Pickupdays API"
+linkTitle: "Pickupdays API"
 date: 2023-03-14
 description: >
-  Deze pagina geeft meer info over de verschillende **planning** endpoints
+  Deze pagina geeft meer info over de verschillende **pickupdays** endpoints
 ---
 ## De /pickupdays endpoints
 

--- a/docs/content/nl/docs/API/ronde.md
+++ b/docs/content/nl/docs/API/ronde.md
@@ -1,8 +1,8 @@
 ---
-categories: ["api", "containers"]
-tags: ["api", "examples", "containers"]
-title: "Containers API"
-linkTitle: "Containers API"
+categories: ["api", "ronde"]
+tags: ["api", "examples", "ronde"]
+title: "Ronde API"
+linkTitle: "Ronde API"
 date: 2023-03-14
 description: >
   Deze pagina geeft meer info over de verschillende **ronde** endpoints


### PR DESCRIPTION
Er stond 3x "Containers API" als titel in de documentatie maar met andere inhoud