### PR TITLE
Dashboard ronde kaart #114

### DIFF
--- a/frontend/src/components/admin/DashboardRoundCard.vue
+++ b/frontend/src/components/admin/DashboardRoundCard.vue
@@ -1,6 +1,11 @@
 <!--
   Een component die een een overzicht geeft hoe ver een ronde al in proces is. Als input verwachten we
   een data object die alle nodige informatie bevat.
+    Name: String
+    Datum: String
+    Progress: Int range: 0-100
+    plannend: Bool
+    students: [String]
 -->
 
 <template>
@@ -49,7 +54,7 @@
 <script>
 import NormalButton from '@/components/NormalButton'
 export default {
-  name: 'RondeCard',
+  name: 'DashboardRoundCard',
   components: { NormalButton },
   props: {
     data: {


### PR DESCRIPTION
close #114 In deze pr staat de code voor het view component Ronde Card.
Figma:
<img width="793" alt="Schermafbeelding 2023-03-27 om 02 02 12" src="https://user-images.githubusercontent.com/77899921/227813238-9b8a8a89-0701-4baa-bbf1-d14da3b42a13.png">
Eindresultaat:
<img width="1252" alt="Schermafbeelding 2023-03-27 om 01 57 13" src="https://user-images.githubusercontent.com/77899921/227813261-b40e4584-6fdc-431b-8e9b-4b84eefb0600.png">
